### PR TITLE
Use `cont` instead of `async`

### DIFF
--- a/core/src/main/scala/daenyth/guava/package.scala
+++ b/core/src/main/scala/daenyth/guava/package.scala
@@ -20,7 +20,6 @@ import cats.effect.{Async, IO}
 import cats.syntax.all._
 import com.google.common.util.concurrent.ListenableFuture
 
-import java.util.concurrent.Executor
 import scala.concurrent.ExecutionException
 import scala.util.control.NonFatal
 


### PR DESCRIPTION
FWIW: this PR is only an optimization (not necessary for correctness) and arguably it makes the implementation more complicated. It ports changes from:
- https://github.com/typelevel/cats-effect/pull/3375
- https://github.com/typelevel/cats-effect/pull/3425